### PR TITLE
feat: add signal to move new users to "editors" group

### DIFF
--- a/apis_ontology/signals
+++ b/apis_ontology/signals
@@ -1,0 +1,13 @@
+import os
+from django.contrib.auth.signals import user_logged_in
+from django.dispatch import receiver
+from django.contrib.auth.models import Group
+
+
+
+@receiver(user_logged_in)
+def add_to_group(sender, user, request, **kwargs):
+    user_list = os.environ.get("AUTH_LDAP_USER_LIST", "").split(",")
+    g1, _ = Group.objects.get_or_create(name='editors')
+    if user.username in user_list:
+        g1.user_set.add(user)


### PR DESCRIPTION
uses a signal to move users to "editors" user group to give them permissions. After logging in first time users need to log out and in again to get the permissions.