### PR TITLE
add manage.py

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+if __name__ == "__main__":
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "apis_ontology.settings")
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError:
+        # The above import may fail for some other reason. Ensure that the
+        # issue is really that Django is missing to avoid masking other
+        # exceptions on Python 2.
+        try:
+            import django  # noqa
+        except ImportError:
+            raise ImportError(
+                "Couldn't import Django. Are you sure it's installed and "
+                "available on your PYTHONPATH environment variable? Did you "
+                "forget to activate a virtual environment?"
+            )
+        raise
+    execute_from_command_line(sys.argv)


### PR DESCRIPTION
This pull request includes a new `manage.py` file to set up the Django environment and handle command-line execution. The most important changes include setting the default Django settings module, importing necessary modules, and handling potential import errors.

Key changes:

* Added code to set the default Django settings module to `apis_ontology.settings`.
* Imported `os` and `sys` modules to manage environment settings and command-line arguments.
* Added error handling to provide a clear message if Django is not installed or the virtual environment is not activated.
* Included the `execute_from_command_line` function to handle command-line execution of Django commands.