### PR TITLE
Include a datamodel menu

### DIFF
--- a/apis_ontology/settings/server_settings.py
+++ b/apis_ontology/settings/server_settings.py
@@ -21,6 +21,7 @@ INSTALLED_APPS += [
 INSTALLED_APPS.remove("apis_ontology")
 INSTALLED_APPS.insert(0, "apis_ontology")
 INSTALLED_APPS = ["apis_core.relations"] + INSTALLED_APPS
+INSTALLED_APPS.append("apis_core.documentation")
 
 LOGGING = {
     "version": 1,

--- a/apis_ontology/templates/base.html
+++ b/apis_ontology/templates/base.html
@@ -6,3 +6,16 @@
 Nomansland: Nomads' Manuscripts Landscape
 {% endif %}
 {% endblock title %}
+
+{% block main-menu %}
+<li class="nav-item dropdown">
+    <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
+        aria-expanded="false">
+        About <span class="caret" />
+    </a>
+    <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+        <a class="dropdown-item" href="{% url 'apis:documentation' %}">Data model</a>
+    </div>
+</li>
+{{ block.super }}
+{% endblock main-menu %}


### PR DESCRIPTION
This pull request includes changes to the `apis_ontology` project to update the installed applications and enhance the main menu in the base template.

Updates to installed applications:

* [`apis_ontology/settings/server_settings.py`](diffhunk://#diff-2903b7820ed1f17f3d8fa1eee95d7bba39d40c18f6810445aa4f3fdfa84636baR24): Added `apis_core.documentation` to the `INSTALLED_APPS` list.

Enhancements to the main menu:

* [`apis_ontology/templates/base.html`](diffhunk://#diff-2d876f80b43737269e59ecad6f487d5c40d5cff2bed8b9645401bc561bb2785aR9-R21): Added a dropdown menu item for "About" with a link to the "Data model" documentation.