### PR TITLE
remove unused imports

### DIFF
--- a/apis_ontology/management/commands/import_data.py
+++ b/apis_ontology/management/commands/import_data.py
@@ -1,14 +1,11 @@
 from collections import defaultdict
 from django.core.management.base import BaseCommand
 import pandas as pd
-from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
-from apis_core.apis_relations.models import Property
-import pandas as pd
+
 from tqdm.auto import tqdm
 
 from apis_core.collections.models import SkosCollection, SkosCollectionContentObject
-import apis_ontology
 from apis_ontology.models import (
     Event,
     EventType,


### PR DESCRIPTION
This pull request includes changes to the `apis_ontology/management/commands/import_data.py` file to clean up and optimize the import statements by removing unused imports.

Codebase simplification:

* [`apis_ontology/management/commands/import_data.py`](diffhunk://#diff-a7ad6afa16cd0c2af2b0ffbad788d5b9aee384ae025c00f4a6b0bda259868968L4-L11): Removed unused imports from `django.apps`, `apis_core.apis_relations.models`, and `apis_ontology`.