### PR TITLE
support case insensitive input

### DIFF
--- a/apis_ontology/date_utils.py
+++ b/apis_ontology/date_utils.py
@@ -45,8 +45,14 @@ def incomplete_date_to_interval(date_str) -> Tuple[datetime, datetime, datetime]
     date_str = date_str.replace("fl.", "").replace("flourish", "").strip()
     # TODO: Should we make an assumption of date of birth or death
     # when a flourish date is provided?
-    if date_str.endswith("AH") or date_str.endswith("BH"):
+    if date_str.endswith("ah") or date_str.endswith("bh"):
         return incomplete_hijridate_to_interval(date_str)
+
+    bce = date_str.endswith("bc")
+    if bce:
+        date_str = date_str.replace("bc", "")
+        # TODO: Figure out how to handle BC dates
+        return None, None, None
 
     date_str = date_str.strip()
     if date_str.endswith("c"):
@@ -55,12 +61,6 @@ def incomplete_date_to_interval(date_str) -> Tuple[datetime, datetime, datetime]
         to_date = datetime(century * 100 + 99, 12, 31)
         dates.set_range(from_date, to_date)
         return dates.tuple()
-
-    bce = date_str.endswith("BC")
-    if bce:
-        date_str = date_str.replace("BC", "")
-        # TODO: Figure out how to handle BC dates
-        return None, None, None
 
     date_parts = date_str.split("-")
     year = int(date_parts[0]) if not bce else int(date_parts[0])
@@ -103,7 +103,7 @@ def nomansland_dateparser(
     """
     # https://nomansland.acdh-dev.oeaw.ac.at/apis/entities/entity/manuscript/21153/detail
     # 	- before 496/1102-3v
-    date_string = date_string.strip()
+    date_string = date_string.strip().lower()
     dates = DateTuple()
     try:
         if " - " in date_string:
@@ -116,7 +116,7 @@ def nomansland_dateparser(
         elif date_string.endswith("-"):
             _, dates.from_date, _ = incomplete_date_to_interval(date_string[:-1])
         else:
-            pattern_desc_range = r"\b(before|not after|not before|after)\s+(\S+)"
+            pattern_desc_range = r"\b(before|not after|not before|after)\s+(.+)"
             matches_desc_range = re.finditer(pattern_desc_range, date_string)
             groups_desc_range = {
                 match.group(1): match.group(2) for match in matches_desc_range

--- a/apis_ontology/hijri_util.py
+++ b/apis_ontology/hijri_util.py
@@ -24,8 +24,8 @@ def incomplete_hijridate_to_interval(
     (YYYY or YYY or YY or Y)(-MM or M optional)(-DD or D optional)
     """
     hijri_date = hijri_date.strip()
-    before_hijri = hijri_date.endswith("BH")
-    hijri_date = hijri_date.replace("AH", "").replace("BH", "").strip()
+    before_hijri = hijri_date.endswith("bh")
+    hijri_date = hijri_date.replace("ah", "").replace("bh", "").strip()
 
     dates = DateTuple()
     hijri_month = None

--- a/apis_ontology/tests/test_date_utils.py
+++ b/apis_ontology/tests/test_date_utils.py
@@ -109,3 +109,22 @@ class ParseHDateTestCase(SimpleTestCase):
         self.assertEqual(from_date, dt.fromisoformat("0600-01-01"))
         self.assertEqual(to_date, dt.fromisoformat("0699-12-31"))
         self.assertEqual(sort_date, dt.fromisoformat("0649-12-31"))
+
+    def test_hijri_date(self):
+        sort_date, from_date, to_date = nomansland_dateparser("700 AH")
+        self.assertEqual(from_date, dt.fromisoformat("1300-09-16"))
+        self.assertEqual(to_date, dt.fromisoformat("1301-09-04"))
+
+    def test_case_insensitive(self):
+        sort_date, from_date, to_date = nomansland_dateparser("7C")
+        self.assertEqual(from_date, dt.fromisoformat("0600-01-01"))
+        self.assertEqual(to_date, dt.fromisoformat("0699-12-31"))
+        self.assertEqual(sort_date, dt.fromisoformat("0649-12-31"))
+
+        sort_date, from_date, to_date = nomansland_dateparser("700 ah")
+        self.assertEqual(from_date, dt.fromisoformat("1300-09-16"))
+        self.assertEqual(to_date, dt.fromisoformat("1301-09-04"))
+
+        sort_date, from_date, to_date = nomansland_dateparser("After 700 ah")
+        self.assertEqual(from_date, dt.fromisoformat("1301-09-05"))
+        self.assertEqual(to_date, None)


### PR DESCRIPTION
This pull request includes several changes to improve date parsing functionality and add new test cases. The most important changes include making date parsing case-insensitive, handling BC dates, and adding new test cases for Hijri dates and case insensitivity.

Improvements to date parsing:

* [`apis_ontology/date_utils.py`](diffhunk://#diff-9595df345796a9e063d2d0101cff4e41427bcef58247054c5c673f6159f883a9L48-R56): Modified the `incomplete_date_to_interval` function to handle lowercase "ah" and "bh" suffixes and added handling for "bc" dates. [[1]](diffhunk://#diff-9595df345796a9e063d2d0101cff4e41427bcef58247054c5c673f6159f883a9L48-R56) [[2]](diffhunk://#diff-9595df345796a9e063d2d0101cff4e41427bcef58247054c5c673f6159f883a9L59-L64)
* [`apis_ontology/date_utils.py`](diffhunk://#diff-9595df345796a9e063d2d0101cff4e41427bcef58247054c5c673f6159f883a9L106-R106): Updated the `nomansland_dateparser` function to convert date strings to lowercase for consistent parsing and adjusted the regex pattern to handle more descriptive date ranges. [[1]](diffhunk://#diff-9595df345796a9e063d2d0101cff4e41427bcef58247054c5c673f6159f883a9L106-R106) [[2]](diffhunk://#diff-9595df345796a9e063d2d0101cff4e41427bcef58247054c5c673f6159f883a9L119-R119)
* [`apis_ontology/hijri_util.py`](diffhunk://#diff-dd1e025d84281c235421f239dbecc9bf04cde85790729a90f8b4706542929fedL27-R28): Adjusted the `incomplete_hijridate_to_interval` function to handle lowercase "ah" and "bh" suffixes.

Addition of new test cases:

* [`apis_ontology/tests/test_date_utils.py`](diffhunk://#diff-bc458816ac7c9d80eac466cfb50275f871c4c1482e8f7091404ef0e9f7ced28dR112-R130): Added new test cases to verify the correct parsing of Hijri dates and case-insensitive date strings.