### PR TITLE
fix(command): import script to use class name

### DIFF
--- a/apis_ontology/management/commands/import_relations.py
+++ b/apis_ontology/management/commands/import_relations.py
@@ -141,10 +141,10 @@ class Command(BaseCommand):
             for i, row in tqdm(relation_rows.iterrows(), total=relation_rows.shape[0]):
                 RelModel = apps.get_model(get_rel_class(row.fields["relation_type"]))
                 rel_data = {"pk_old": row.pk, **row.fields}
-                subj_key = None
-                obj_key = None
+                subj_key = ""
+                obj_key = ""
                 for subj_model in RelModel.subj_model:
-                    subj_model = subj_model.removeprefix("apis_ontology.")
+                    subj_model = subj_model.__name__.lower()
                     if f"related_{subj_model}A" in rel_data.keys():
                         subj_key = f"related_{subj_model}A"
                         obj_key = f"related_{subj_model}B"
@@ -153,9 +153,9 @@ class Command(BaseCommand):
                         subj_key = f"related_{subj_model}"
                         try:
                             obj_key = [
-                                f"related_{obj_model.removeprefix('apis_ontology.')}"
+                                f"related_{obj_model.__name__.lower()}"
                                 for obj_model in RelModel.obj_model
-                                if f"related_{obj_model.removeprefix('apis_ontology.')}"
+                                if f"related_{obj_model.__name__.lower()}"
                                 in rel_data.keys()
                             ][0]
                             break
@@ -188,7 +188,7 @@ class Command(BaseCommand):
                     }
                     rel, _ = RelModel.objects.get_or_create(**data)
                 except Exception as e:
-                    print(e)
+                    print(repr(e))
                     break
 
         ### handle command

--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -384,8 +384,8 @@ class NomanslandRelationMixin(
 
 class ACopyOf(Relation, NomanslandRelationMixin, NomanslandDateMixin, VersionMixin):
     relation_type_old = [15]  # pk of Property in apis_relations
-    subj_model = Expression
-    obj_model = Work
+    subj_model = [Expression]
+    obj_model = [Work]
 
     @classmethod
     def reverse_name(cls) -> str:
@@ -1280,8 +1280,8 @@ class TranslationOf(
 
 class UsedIn(Relation, NomanslandRelationMixin, NomanslandDateMixin, VersionMixin):
     relation_type_old = [142]  # pk of Property in apis_relations
-    subj_model = Place
-    obj_model = Place
+    subj_model = [Place]
+    obj_model = [Place]
 
     @classmethod
     def reverse_name(cls) -> str:


### PR DESCRIPTION
in subj_model and obj_model fields

This pull request includes several changes to improve the handling of relation instances and relation models in the `apis_ontology` module. The most important changes include modifying how subject and object keys are handled, updating the `subj_model` and `obj_model` attributes, and enhancing error logging.

Improvements to handling relation instances:

* [`apis_ontology/management/commands/import_relations.py`](diffhunk://#diff-d5e0b6045dee08a815e0dff1df60af9a2a6d0341c78f2325d9af4b84e1efa356L144-R147): Changed `subj_key` and `obj_key` initialization from `None` to empty strings to avoid potential issues with uninitialized variables.
* [`apis_ontology/management/commands/import_relations.py`](diffhunk://#diff-d5e0b6045dee08a815e0dff1df60af9a2a6d0341c78f2325d9af4b84e1efa356L156-R158): Updated the retrieval of model names to use the `__name__.lower()` method instead of `removeprefix("apis_ontology.")` for better compatibility and readability.

Enhancements to relation models:

* [`apis_ontology/models.py`](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1L387-R388): Changed the `subj_model` and `obj_model` attributes from single instances to lists containing the instances, ensuring consistency and future extensibility. [[1]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1L387-R388) [[2]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1L1283-R1284)

Improved error logging:

* [`apis_ontology/management/commands/import_relations.py`](diffhunk://#diff-d5e0b6045dee08a815e0dff1df60af9a2a6d0341c78f2325d9af4b84e1efa356L191-R191): Updated error logging to use `repr(e)` instead of `print(e)` for more detailed and informative error messages.