### PR TITLE
remove django-debug-toolbar

### DIFF
--- a/apis_ontology/settings/server_settings.py
+++ b/apis_ontology/settings/server_settings.py
@@ -21,7 +21,6 @@ ADDITIONAL_APPS = [
     "django_interval",
     "apis_core.documentation",
     "apis_bibsonomy",
-    "debug_toolbar",
 ]
 
 for app in ADDITIONAL_APPS:
@@ -71,8 +70,4 @@ APIS_BIBSONOMY = [
         "API key": os.environ.get("APIS_BIBSONOMY_PASSWORD"),
         "group": "2801369",
     }
-]
-
-MIDDLEWARE += [
-    "debug_toolbar.middleware.DebugToolbarMiddleware",
 ]

--- a/apis_ontology/urls.py
+++ b/apis_ontology/urls.py
@@ -23,13 +23,3 @@ urlpatterns += [
 ]
 
 urlpatterns += [path("", include("django_interval.urls"))]
-
-from django.conf import settings
-from django.urls import include, path
-
-if settings.DEBUG:
-    import debug_toolbar
-
-    urlpatterns = [
-        path("__debug__/", include(debug_toolbar.urls)),
-    ] + urlpatterns

--- a/poetry.lock
+++ b/poetry.lock
@@ -797,21 +797,6 @@ jinja2 = ["jinja2 (>=2.9.6)"]
 tests = ["jinja2 (>=2.9.6)", "pytest", "pytest-cov", "pytest-django", "pytest-ruff"]
 
 [[package]]
-name = "django-debug-toolbar"
-version = "5.0.1"
-description = "A configurable set of panels that display various debug information about the current request/response."
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "django_debug_toolbar-5.0.1-py3-none-any.whl", hash = "sha256:7456cc2e951db37dab335686db7803c4a0ecb6736d120705f6668db9548bf49f"},
-    {file = "django_debug_toolbar-5.0.1.tar.gz", hash = "sha256:296f6f18a80710e84fbb8361538ae5ec522a75ebe9ab67db34bcf1026cbeb420"},
-]
-
-[package.dependencies]
-django = ">=4.2.9"
-sqlparse = ">=0.2"
-
-[[package]]
 name = "django-extensions"
 version = "3.2.3"
 description = "Extensions for Django"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ pandas = "^2.2.2"
 tqdm = "^4.67.1"
 apis-bibsonomy = "^0.13.1"
 django-interval = "^0.2.5"
-django-debug-toolbar = "^5.0.1"
 
 [tool.poetry.group.dev.dependencies]
 jupyterlab = "^4.3.3"


### PR DESCRIPTION
This pull request focuses on removing the `django-debug-toolbar` from the project. The changes include updates to the settings, URL configuration, and dependencies.

### Removal of `django-debug-toolbar`:

* [`apis_ontology/settings/server_settings.py`](diffhunk://#diff-2903b7820ed1f17f3d8fa1eee95d7bba39d40c18f6810445aa4f3fdfa84636baL24): Removed `debug_toolbar` from the `ADDITIONAL_APPS` list and `DebugToolbarMiddleware` from the `MIDDLEWARE` list. [[1]](diffhunk://#diff-2903b7820ed1f17f3d8fa1eee95d7bba39d40c18f6810445aa4f3fdfa84636baL24) [[2]](diffhunk://#diff-2903b7820ed1f17f3d8fa1eee95d7bba39d40c18f6810445aa4f3fdfa84636baL75-L78)
* [`apis_ontology/urls.py`](diffhunk://#diff-f4051c017f27901a819ed4f672fc890dbc5d9cf69c4579c85680f109ca3902c2L26-L35): Removed the conditional inclusion of `debug_toolbar` URLs when `settings.DEBUG` is true.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L22): Removed the `django-debug-toolbar` dependency.