### PR TITLE
fix(import): prevent duplication during import

### DIFF
--- a/apis_ontology/management/commands/import_data.py
+++ b/apis_ontology/management/commands/import_data.py
@@ -201,7 +201,8 @@ class Command(BaseCommand):
                         old_data["date_of_death"] = old_data["end"]
                         old_data.pop("end")
 
-                    p, _ = Person.objects.get_or_create(**old_data)
+                    p, _ = Person.objects.get_or_create(pk_old=old_data["pk_old"])
+                    p.__dict__.update(**old_data)
 
                     if title_ids:
                         for title_id in title_ids:
@@ -243,7 +244,8 @@ class Command(BaseCommand):
                     place_type_pk = old_data.get("kind")
                     old_data.pop("kind")
 
-                p, _ = Place.objects.get_or_create(**old_data)
+                p, _ = Place.objects.get_or_create(pk_old=old_data["pk_old"])
+                p.__dict__.update(**old_data)
 
                 if place_type_pk:
                     place_type_data = get_base_vocab_data(place_type_pk)
@@ -270,8 +272,8 @@ class Command(BaseCommand):
                     old_data.pop("kind")
 
                 if old_data:
-                    p, _ = Institution.objects.get_or_create(**old_data)
-
+                    p, _ = Institution.objects.get_or_create(pk_old=old_data["pk_old"])
+                    p.__dict__.update(**old_data)
                     if i_type_pk:
                         i_type_data = get_base_vocab_data(i_type_pk)
                         i_type, _ = InstitutionType.objects.get_or_create(**i_type_data)
@@ -297,7 +299,8 @@ class Command(BaseCommand):
                     old_data.pop("kind")
 
                 if old_data:
-                    p, _ = Event.objects.get_or_create(**old_data)
+                    p, _ = Event.objects.get_or_create(pk_old=old_data["pk_old"])
+                    p.__dict__.update(**old_data)
 
                     if type_pk:
                         type_data = get_base_vocab_data(type_pk)
@@ -328,7 +331,8 @@ class Command(BaseCommand):
                     old_data.pop("subject_headings")
 
                 if old_data:
-                    p, _ = Work.objects.get_or_create(**old_data)
+                    p, _ = Work.objects.get_or_create(pk_old=old_data["pk_old"])
+                    p.__dict__.update(**old_data)
 
                     if type_pk:
                         type_data = get_base_vocab_data(type_pk)
@@ -370,7 +374,10 @@ class Command(BaseCommand):
                         old_data.pop("language")
 
                     if old_data:
-                        p, _ = Expression.objects.get_or_create(**old_data)
+                        p, _ = Expression.objects.get_or_create(
+                            pk_old=old_data["pk_old"]
+                        )
+                        p.__dict__.update(**old_data)
 
                         if language_ids:
                             for l_id in language_ids:
@@ -415,7 +422,8 @@ class Command(BaseCommand):
                         condition_pks = old_data.get("manuscript_conditions")
                         old_data.pop("manuscript_conditions")
 
-                    p, _ = Manuscript.objects.get_or_create(**old_data)
+                    p, _ = Manuscript.objects.get_or_create(pk_old=old_data["pk_old"])
+                    p.__dict__.update(**old_data)
 
                     if condition_pks:
                         for pk in condition_pks:
@@ -447,8 +455,10 @@ class Command(BaseCommand):
                         mpart_type_pk = old_data.get("type")
                         old_data.pop("type")
 
-                    p, _ = ManuscriptPart.objects.get_or_create(**old_data)
-
+                    p, _ = ManuscriptPart.objects.get_or_create(
+                        pk_old=old_data["pk_old"]
+                    )
+                    p.__dict__.update(**old_data)
                     if mpart_type_pk:
                         mpart_type_data = get_base_vocab_data(mpart_type_pk)
                         mpart_type, _ = ManuscriptPartType.objects.get_or_create(


### PR DESCRIPTION
when updated data from old APIS is imported

This pull request includes significant changes to the `import_data.py` file in the `apis_ontology` management commands. The changes focus on updating the way objects are created or updated in the database by using the `pk_old` field for object retrieval and then updating the object attributes.

The most important changes include:

* [`import_persons()`](diffhunk://#diff-a7ad6afa16cd0c2af2b0ffbad788d5b9aee384ae025c00f4a6b0bda259868968L204-R205): Modified to use `pk_old` for retrieving `Person` objects and updating their attributes.
* [`import_places()`](diffhunk://#diff-a7ad6afa16cd0c2af2b0ffbad788d5b9aee384ae025c00f4a6b0bda259868968L246-R248): Modified to use `pk_old` for retrieving `Place` objects and updating their attributes.
* [`import_institutions()`](diffhunk://#diff-a7ad6afa16cd0c2af2b0ffbad788d5b9aee384ae025c00f4a6b0bda259868968L273-R276): Modified to use `pk_old` for retrieving `Institution` objects and updating their attributes.
* [`import_events()`](diffhunk://#diff-a7ad6afa16cd0c2af2b0ffbad788d5b9aee384ae025c00f4a6b0bda259868968L300-R303): Modified to use `pk_old` for retrieving `Event` objects and updating their attributes.
* [`import_works()`](diffhunk://#diff-a7ad6afa16cd0c2af2b0ffbad788d5b9aee384ae025c00f4a6b0bda259868968L331-R335): Modified to use `pk_old` for retrieving `Work` objects and updating their attributes.

These changes ensure that the objects are correctly identified and updated, improving data integrity during the import process.