### PR TITLE
fix: export links with relation subclass

### DIFF
--- a/apis_ontology/management/commands/export-nodes-links.py
+++ b/apis_ontology/management/commands/export-nodes-links.py
@@ -25,7 +25,7 @@ class Command(BaseCommand):
 
         nodes = []
         links = []
-        for rel in tqdm(Relation.objects.all()):
+        for rel in tqdm(Relation.objects.select_subclasses().all()):
             nodes.append(
                 {
                     "id": rel.subj.pk,


### PR DESCRIPTION
This pull request includes a change to the `apis_ontology/management/commands/export-nodes-links.py` file, specifically within the `remove_duplicates` function. The change optimizes the query used to retrieve relations by using `select_subclasses()` instead of the generic `all()` method.

Optimization of query:

* [`apis_ontology/management/commands/export-nodes-links.py`](diffhunk://#diff-33e0ee6ebe00ae96f55193106fb883f740e0aa076837a5f3e1be6a67319d04b1L28-R28): Modified the loop to use `Relation.objects.select_subclasses().all()` for better performance when retrieving relation objects.