### PR TITLE
import expression with correct language data

### DIFF
--- a/apis_ontology/management/commands/import_data.py
+++ b/apis_ontology/management/commands/import_data.py
@@ -382,7 +382,7 @@ class Command(BaseCommand):
                         if language_ids:
                             for l_id in language_ids:
                                 l, _ = Language.objects.get_or_create(
-                                    get_base_vocab_data(l_id)
+                                    **get_base_vocab_data(l_id)
                                 )
                                 p.language.add(l)
 
@@ -396,7 +396,7 @@ class Command(BaseCommand):
                             script_type_body, _ = ScriptType.objects.get_or_create(
                                 **VOCAB_FIELDS["script_body"]
                             )
-                            p.scrip_type_body = script_type_body
+                            p.script_type_body = script_type_body
 
                         p.save()
 


### PR DESCRIPTION
and fix typo in fieldname

This pull request includes changes to the `import_expressions` function in the `apis_ontology/management/commands/import_data.py` file. The most important changes are related to the handling of keyword arguments and fixing a typo in a variable name.

Changes to keyword arguments and variable names:

* Modified the `get_or_create` method call to use keyword argument unpacking with `**get_base_vocab_data(l_id)` instead of `get_base_vocab_data(l_id)` for `Language` objects.
* Corrected a typo by changing `p.scrip_type_body` to `p.script_type_body` when assigning the `ScriptType` object.