### PR TITLE
command: modify bad date report to include edit url

### DIFF
--- a/apis_ontology/management/commands/report_bad_dates.py
+++ b/apis_ontology/management/commands/report_bad_dates.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
                         ):
                             bad_dates.append(
                                 {
-                                    "object": f"[{str(obj)}]({BASE_URL + obj.get_absolute_url()})",
+                                    "object": f"[{str(obj)}]({BASE_URL + obj.get_edit_url()})",
                                     "field": f.name,
                                     "value": getattr(obj, f.name),
                                 }
@@ -38,7 +38,7 @@ class Command(BaseCommand):
         if bad_dates:
             import pandas as pd
 
-            pd.DataFrame(bad_dates).to_markdown("bad_dates.md")
+            pd.DataFrame(bad_dates).to_markdown("bad_dates.md", index=False)
             print(f"{len(bad_dates)} bad dates found. See bad_dates.md for details.")
 
         else:


### PR DESCRIPTION
This pull request includes changes to the `apis_ontology/management/commands/report_bad_dates.py` file to improve the handling and reporting of bad dates. The most important changes include updating the URL used in the report and modifying the DataFrame export to exclude the index.

Improvements to bad dates reporting:

* Updated the URL in the report to use the object's edit URL instead of the absolute URL. (`apis_ontology/management/commands/report_bad_dates.py`)
* Modified the DataFrame export to exclude the index when generating the markdown file. (`apis_ontology/management/commands/report_bad_dates.py`)