### PR TITLE
support approximate dates with qualifiers

### DIFF
--- a/apis_ontology/tests/test_date_utils.py
+++ b/apis_ontology/tests/test_date_utils.py
@@ -100,15 +100,17 @@ class ParseHDateTestCase(SimpleTestCase):
         self.assertIsNone(to_date)
 
     def test_flourish_date(self):
-        sort_date, from_date, to_date = nomansland_dateparser("fl. 7c")
-        self.assertEqual(from_date, dt.fromisoformat("0600-01-01"))
-        self.assertEqual(to_date, dt.fromisoformat("0699-12-31"))
-        self.assertEqual(sort_date, dt.fromisoformat("0649-12-31"))
+        sort_date, from_date, to_date = nomansland_dateparser("fl. 1780")
+        self.assertEqual(from_date, dt.fromisoformat("1760-01-01"))
+        self.assertEqual(to_date, dt.fromisoformat("1800-01-01"))
 
-        sort_date, from_date, to_date = nomansland_dateparser("flourish 7c ")
-        self.assertEqual(from_date, dt.fromisoformat("0600-01-01"))
-        self.assertEqual(to_date, dt.fromisoformat("0699-12-31"))
-        self.assertEqual(sort_date, dt.fromisoformat("0649-12-31"))
+        sort_date, from_date, to_date = nomansland_dateparser("fl. 1780-05")
+        self.assertEqual(from_date, dt.fromisoformat("1760-05-01"))
+        self.assertEqual(to_date, dt.fromisoformat("1800-05-01"))
+
+        sort_date, from_date, to_date = nomansland_dateparser("fl. 1780-05-11")
+        self.assertEqual(from_date, dt.fromisoformat("1760-05-11"))
+        self.assertEqual(to_date, dt.fromisoformat("1800-05-11"))
 
     def test_hijri_date(self):
         sort_date, from_date, to_date = nomansland_dateparser("700 AH")
@@ -128,3 +130,16 @@ class ParseHDateTestCase(SimpleTestCase):
         sort_date, from_date, to_date = nomansland_dateparser("After 700 ah")
         self.assertEqual(from_date, dt.fromisoformat("1301-09-05"))
         self.assertEqual(to_date, None)
+
+    def test_circa_dates(self):
+        sort_date, from_date, to_date = nomansland_dateparser("c. 1780")
+        self.assertEqual(from_date, dt.fromisoformat("1770-01-01"))
+        self.assertEqual(to_date, dt.fromisoformat("1790-01-01"))
+
+        sort_date, from_date, to_date = nomansland_dateparser("c. 1780-05")
+        self.assertEqual(from_date, dt.fromisoformat("1770-05-01"))
+        self.assertEqual(to_date, dt.fromisoformat("1790-05-01"))
+
+        sort_date, from_date, to_date = nomansland_dateparser("c. 1780-05-11")
+        self.assertEqual(from_date, dt.fromisoformat("1770-05-11"))
+        self.assertEqual(to_date, dt.fromisoformat("1790-05-11"))


### PR DESCRIPTION
circa (c.): ± 10 years
flourish(fl.): ± 20 years

closes #80 

This pull request to `apis_ontology/date_utils.py` introduces a new function to handle approximate dates and updates the existing date parsing logic to support new date prefixes. It also includes corresponding test cases to ensure the new functionality works as expected.

### New functionality for handling approximate dates:
* [`apis_ontology/date_utils.py`](diffhunk://#diff-9595df345796a9e063d2d0101cff4e41427bcef58247054c5c673f6159f883a9R34-R52): Added the `approximate_date` function to handle date ranges for prefixes "fl" (flourish) and "c" (circa).

### Updates to date parsing logic:
* [`apis_ontology/date_utils.py`](diffhunk://#diff-9595df345796a9e063d2d0101cff4e41427bcef58247054c5c673f6159f883a9L49-R84): Modified `incomplete_date_to_interval` to utilize the `approximate_date` function for handling the "fl" and "c" prefixes. [[1]](diffhunk://#diff-9595df345796a9e063d2d0101cff4e41427bcef58247054c5c673f6159f883a9L49-R84) [[2]](diffhunk://#diff-9595df345796a9e063d2d0101cff4e41427bcef58247054c5c673f6159f883a9R125-R127)

### Added test cases for new functionality:
* [`apis_ontology/tests/test_date_utils.py`](diffhunk://#diff-bc458816ac7c9d80eac466cfb50275f871c4c1482e8f7091404ef0e9f7ced28dL103-R113): Added test cases for "fl" and "c" prefixes to ensure the `nomansland_dateparser` function correctly handles approximate dates. [[1]](diffhunk://#diff-bc458816ac7c9d80eac466cfb50275f871c4c1482e8f7091404ef0e9f7ced28dL103-R113) [[2]](diffhunk://#diff-bc458816ac7c9d80eac466cfb50275f871c4c1482e8f7091404ef0e9f7ced28dR133-R145)

### Import changes:
* [`apis_ontology/date_utils.py`](diffhunk://#diff-9595df345796a9e063d2d0101cff4e41427bcef58247054c5c673f6159f883a9R12-R13): Added import for `relativedelta` from `dateutil` to support the new date range calculations.