### PR TITLE
querysets: allow unaccented search in Autocomplete

### DIFF
--- a/apis_ontology/querysets.py
+++ b/apis_ontology/querysets.py
@@ -1,0 +1,10 @@
+from apis_ontology.filtersets import generic_search_filter
+
+
+def NomanslandMixinAutocompleteQueryset(model, query):
+    """
+    Autocomplete queryset for Nomansland models,
+    making use of generic_search_filter
+    to provide unaccented search results
+    """
+    return generic_search_filter(model.objects.all(), None, query)


### PR DESCRIPTION
closes #117

This pull request introduces a new utility function in `apis_ontology/querysets.py` to enhance autocomplete functionality for Nomansland models by leveraging a generic search filter for unaccented search results.

Enhancements to autocomplete functionality:

* [`apis_ontology/querysets.py`](diffhunk://#diff-c382afc1d30c707a51e7f9c991c03cea9c674b7fde9670ab25aaab8de2d7903fR1-R10): Added the `NomanslandMixinAutocompleteQueryset` function, which uses the `generic_search_filter` to perform unaccented searches on all objects of a given model.