### PR TITLE
refactor: remove redundant lookup into Contains…

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -276,18 +276,13 @@ class ScriptType(GenericModel, models.Model):
 
 class ExpressionQuerySet(models.QuerySet):
     def with_manuscript(self):
+        contains = Contains.objects.filter(obj_object_id=models.OuterRef("id"))
         return self.annotate(
-            # Subquery to get the manuscript related to the Work through Contains
-            manuscript_id=models.Subquery(
-                Contains.objects.filter(obj_object_id=models.OuterRef("id")).values(
-                    "subj_object_id"
-                )[:1]
-            ),
-            # Subquery to get the manuscript name based on the manuscript_id from above
+            manuscript_id=models.Subquery(contains.values("subj_object_id")[:1]),
             manuscript_name=models.Subquery(
-                Manuscript.objects.filter(id=models.OuterRef("manuscript_id")).values(
-                    "name"
-                )[:1]
+                Manuscript.objects.filter(
+                    id=models.Subquery(contains.values("subj_object_id")[:1])
+                ).values("name")[:1]
             ),
         )
 


### PR DESCRIPTION
in the ExpressionQuerySet

Database indices:
```
CREATE INDEX idx_relation_obj_object_id ON relations_relation(obj_object_id);
CREATE INDEX idx_relation_subj_object_id ON relations_relation(subj_object_id);

```

This pull request refactors the `with_manuscript` method in the `ExpressionQuerySet` class to improve code readability and reusability by introducing a reusable variable for the `Contains` query.

Refactoring for readability and reusability:

* [`apis_ontology/models.py`](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1R279-R285): Introduced a `contains` variable to hold the `Contains` query, simplifying the `manuscript_id` and `manuscript_name` subqueries by reusing this variable. This reduces duplication and enhances clarity.